### PR TITLE
Single-use refresh token refactor

### DIFF
--- a/financroo/bank_aggregation_routes.go
+++ b/financroo/bank_aggregation_routes.go
@@ -42,9 +42,7 @@ func (s *Server) WithUser(c *gin.Context) (User, BankTokens, error) {
 		return user, tokens, errors.Wrapf(err, "failed to get user")
 	}
 
-	userStorage := NewUserSecureStorage(s.SecureCookie)
-
-	if tokens, err = userStorage.Read(c); err != nil {
+	if tokens, err = s.UserSecureStorage.Read(c); err != nil {
 		return user, tokens, errors.Wrapf(err, "failed to read user store")
 	}
 

--- a/financroo/bank_aggregation_routes.go
+++ b/financroo/bank_aggregation_routes.go
@@ -11,16 +11,15 @@ import (
 	"github.com/cloudentity/openbanking-sample-apps/models"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-
-	"github.com/cloudentity/acp-client-go/client/oauth2"
 )
 
-func (s *Server) WithUser(c *gin.Context) (User, error) {
+func (s *Server) WithUser(c *gin.Context) (User, BankTokens, error) {
 	var (
 		user   User
 		claims map[string]interface{}
 		sub    string
 		ok     bool
+		tokens []BankToken
 		err    error
 	)
 
@@ -28,31 +27,36 @@ func (s *Server) WithUser(c *gin.Context) (User, error) {
 	token = strings.ReplaceAll(token, "Bearer ", "")
 
 	if token == "" {
-		return user, errors.New("no access token provided")
+		return user, tokens, errors.New("no access token provided")
 	}
 
 	if claims, err = s.LoginClient.Userinfo(token); err != nil {
-		return user, errors.Wrapf(err, "invalid token")
+		return user, tokens, errors.Wrapf(err, "invalid token")
 	}
 
 	if sub, ok = claims["sub"].(string); !ok {
-		return user, errors.New("sub claim is missing")
+		return user, tokens, errors.New("sub claim is missing")
 	}
 
 	if user, err = s.UserRepo.Get(sub); err != nil {
-		return user, errors.Wrapf(err, "failed to get user")
+		return user, tokens, errors.Wrapf(err, "failed to get user")
 	}
 
-	return user, nil
+	userStorage := NewUserSecureStorage(s.SecureCookie)
+
+	if tokens, err = userStorage.Read(c); err != nil {
+		return user, tokens, errors.Wrapf(err, "failed to read user store")
+	}
+
+	return user, tokens, nil
 }
 
-func (s *Server) GetClientWithToken(bank ConnectedBank) (OpenbankingClient, Token, error) {
+func (s *Server) GetClientWithToken(bank ConnectedBank, tokens BankTokens) (OpenbankingClient, string, error) {
 	var (
 		clients Clients
 		client  OpenbankingClient
 		ok      bool
-		token   Token
-		tResp   *oauth2.TokenOK
+		token   string
 		err     error
 	)
 
@@ -60,18 +64,9 @@ func (s *Server) GetClientWithToken(bank ConnectedBank) (OpenbankingClient, Toke
 		return client, token, fmt.Errorf("can't get client for a bank: %s", bank.BankID)
 	}
 
-	if tResp, err = clients.AcpAccountsClient.Acp.Oauth2.Token(
-		oauth2.NewTokenParams().
-			WithAid(clients.AcpAccountsClient.ServerID).
-			WithTid(clients.AcpAccountsClient.TenantID).
-			WithClientID(&clients.AcpAccountsClient.Config.ClientID).
-			WithGrantType("refresh_token").
-			WithRefreshToken(&bank.RefreshToken)); err != nil {
-		return client, token, errors.Wrapf(err, "can't renew access token for a bank: %s", bank.BankID)
+	if token, err = tokens.GetAccessToken(bank.BankID); err != nil {
+		return client, token, err
 	}
-
-	token.AccessToken = tResp.Payload.AccessToken
-	token.RefreshToken = tResp.Payload.RefreshToken
 
 	return clients.BankClient, token, nil
 }
@@ -86,34 +81,29 @@ func (s *Server) GetAccounts() func(ctx *gin.Context) {
 		var (
 			resp         *accounts.GetAccountsOK
 			client       OpenbankingClient
-			token        Token
+			accessToken  string
 			accountsData = []Account{}
 			user         User
+			tokens       BankTokens
 			err          error
 		)
 
-		if user, err = s.WithUser(c); err != nil {
+		if user, tokens, err = s.WithUser(c); err != nil {
 			c.String(http.StatusUnauthorized, err.Error())
 			return
 		}
 
 		// todo parallel
-		for i, b := range user.Banks {
-			if client, token, err = s.GetClientWithToken(b); err != nil {
+		for _, b := range user.Banks {
+			if client, accessToken, err = s.GetClientWithToken(b, tokens); err != nil {
 				c.String(http.StatusUnauthorized, err.Error())
 				return
 			}
-			if err = s.UserRepo.Set(user); err != nil {
-				c.String(http.StatusInternalServerError, fmt.Sprintf("failed to update user: %+v", err))
-				return
-			}
 
-			if resp, err = client.Accounts.GetAccounts(accounts.NewGetAccountsParams().WithAuthorization(token.AccessToken), nil); err != nil {
+			if resp, err = client.Accounts.GetAccounts(accounts.NewGetAccountsParams().WithAuthorization(accessToken), nil); err != nil {
 				c.String(http.StatusUnauthorized, fmt.Sprintf("failed to call bank get accounts: %+v", err))
 				return
 			}
-
-			user.Banks[i].RefreshToken = token.RefreshToken
 
 			for _, a := range resp.Payload.Data.Account {
 				accountsData = append(accountsData, Account{
@@ -139,20 +129,21 @@ func (s *Server) GetBalances() func(ctx *gin.Context) {
 		var (
 			resp         *balances.GetBalancesOK
 			client       OpenbankingClient
-			token        Token
+			accessToken  string
 			balancesData = []Balance{}
+			tokens       BankTokens
 			user         User
 			err          error
 		)
 
-		if user, err = s.WithUser(c); err != nil {
+		if user, tokens, err = s.WithUser(c); err != nil {
 			c.String(http.StatusUnauthorized, err.Error())
 			return
 		}
 
 		// todo parallel
-		for i, b := range user.Banks {
-			if client, token, err = s.GetClientWithToken(b); err != nil {
+		for _, b := range user.Banks {
+			if client, accessToken, err = s.GetClientWithToken(b, tokens); err != nil {
 				c.String(http.StatusUnauthorized, err.Error())
 				return
 			}
@@ -160,12 +151,10 @@ func (s *Server) GetBalances() func(ctx *gin.Context) {
 				c.String(http.StatusInternalServerError, fmt.Sprintf("failed to update user: %+v", err))
 			}
 
-			if resp, err = client.Balances.GetBalances(balances.NewGetBalancesParams().WithAuthorization(token.AccessToken), nil); err != nil {
+			if resp, err = client.Balances.GetBalances(balances.NewGetBalancesParams().WithAuthorization(accessToken), nil); err != nil {
 				c.String(http.StatusUnauthorized, fmt.Sprintf("failed to call bank get balances: %+v", err))
 				return
 			}
-
-			user.Banks[i].RefreshToken = token.RefreshToken
 
 			for _, a := range resp.Payload.Data.Balance {
 				balancesData = append(balancesData, Balance{
@@ -191,33 +180,29 @@ func (s *Server) GetTransactions() func(ctx *gin.Context) {
 		var (
 			resp             *transactions.GetTransactionsOK
 			client           OpenbankingClient
-			token            Token
+			accessToken      string
 			transactionsData = []Transaction{}
+			tokens           BankTokens
 			user             User
 			err              error
 		)
 
-		if user, err = s.WithUser(c); err != nil {
+		if user, tokens, err = s.WithUser(c); err != nil {
 			c.String(http.StatusUnauthorized, err.Error())
 			return
 		}
 
 		// todo parallel
-		for i, b := range user.Banks {
-			if client, token, err = s.GetClientWithToken(b); err != nil {
+		for _, b := range user.Banks {
+			if client, accessToken, err = s.GetClientWithToken(b, tokens); err != nil {
 				c.String(http.StatusUnauthorized, err.Error())
 				return
 			}
-			if err = s.UserRepo.Set(user); err != nil {
-				c.String(http.StatusInternalServerError, fmt.Sprintf("failed to update user: %+v", err))
-			}
 
-			if resp, err = client.Transactions.GetTransactions(transactions.NewGetTransactionsParams().WithAuthorization(token.AccessToken), nil); err != nil {
+			if resp, err = client.Transactions.GetTransactions(transactions.NewGetTransactionsParams().WithAuthorization(accessToken), nil); err != nil {
 				c.String(http.StatusUnauthorized, fmt.Sprintf("failed to call bank get transactions: %+v", err))
 				return
 			}
-
-			user.Banks[i].RefreshToken = token.RefreshToken
 
 			for _, a := range resp.Payload.Data.Transaction {
 				transactionsData = append(transactionsData, Transaction{

--- a/financroo/clients.go
+++ b/financroo/clients.go
@@ -6,12 +6,71 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/cloudentity/acp-client-go/client/oauth2"
+	"github.com/cloudentity/acp-client-go/models"
 	obc "github.com/cloudentity/openbanking-sample-apps/client"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/pkg/errors"
 
 	acpclient "github.com/cloudentity/acp-client-go"
 )
+
+type Clients struct {
+	AcpAccountsClient acpclient.Client
+	AcpPaymentsClient acpclient.Client
+	BankClient        OpenbankingClient
+}
+
+func (c *Clients) RenewAccountsToken(bank ConnectedBank) (*models.TokenResponse, error) {
+	var (
+		resp *oauth2.TokenOK
+		err  error
+	)
+
+	if resp, err = c.AcpAccountsClient.Acp.Oauth2.Token(
+		oauth2.NewTokenParams().
+			WithAid(c.AcpAccountsClient.ServerID).
+			WithTid(c.AcpAccountsClient.TenantID).
+			WithClientID(&c.AcpAccountsClient.Config.ClientID).
+			WithGrantType("refresh_token").
+			WithRefreshToken(&bank.RefreshToken)); err != nil {
+		return nil, errors.Wrapf(err, "can't renew access token for a bank: %s", bank.BankID)
+	}
+
+	return resp.Payload, nil
+}
+
+func InitClients(config Config) (map[BankID]Clients, error) {
+	var (
+		clients              = map[BankID]Clients{}
+		acpAccountsWebClient acpclient.Client
+		acpPaymentsWebClient acpclient.Client
+		bankClient           OpenbankingClient
+		err                  error
+	)
+
+	for _, bank := range config.Banks {
+		if acpAccountsWebClient, err = NewAcpClient(config, bank, "/api/callback"); err != nil {
+			return clients, errors.Wrapf(err, "failed to init acp web client for bank: %s", bank.ID)
+		}
+
+		if acpPaymentsWebClient, err = NewAcpClient(config, bank, "/api/domestic/callback"); err != nil {
+			return clients, errors.Wrapf(err, "failed to init acp web client for bank: %s", bank.ID)
+		}
+
+		if bankClient, err = NewOpenbankingClient(bank); err != nil {
+			return clients, errors.Wrapf(err, "failed to init client for bank: %s", bank.ID)
+		}
+
+		clients[bank.ID] = Clients{
+			AcpAccountsClient: acpAccountsWebClient,
+			AcpPaymentsClient: acpPaymentsWebClient,
+			BankClient:        bankClient,
+		}
+	}
+
+	return clients, nil
+}
 
 func NewAcpClient(c Config, cfg BankConfig, redirect string) (acpclient.Client, error) {
 	var (
@@ -77,11 +136,6 @@ func NewLoginClient(c Config) (acpclient.Client, error) {
 	}
 
 	return client, nil
-}
-
-type Token struct {
-	AccessToken  string
-	RefreshToken string
 }
 
 type OpenbankingClient struct {

--- a/financroo/config.go
+++ b/financroo/config.go
@@ -15,6 +15,8 @@ func init() {
 	viper.SetDefault("UI_URL", "")
 	viper.SetDefault("CERT_FILE", "")
 	viper.SetDefault("KEY_FILE", "")
+	viper.SetDefault("COOKIE_HASH_KEY", []byte("secret-key"))
+	viper.SetDefault("COOKIE_BLOCK_KEY", []byte("this-is-32-len-block-key"))
 }
 
 type ClientConfig struct {
@@ -62,6 +64,8 @@ type Config struct {
 	UIURL          string `mapstructure:"ui_url" validate:"required,url"`
 	CertFile       string `mapstructure:"cert_file" validate:"required"`
 	KeyFile        string `mapstructure:"key_file" validate:"required"`
+	CookieHashKey  []byte `mapstructure:"cookie_hash_key"`
+	CookieBlockKey []byte `mapstructure:"cookie_block_key"`
 	Login          LoginConfig
 	Banks          []BankConfig
 	FeatureFlags   FeatureFlags `mapstructure:"feature_flags"`

--- a/financroo/connect_bank_routes.go
+++ b/financroo/connect_bank_routes.go
@@ -215,8 +215,6 @@ func (s *Server) DisconnectBank() func(*gin.Context) {
 		}
 		user.Banks = cb
 
-		// todo clear user storage
-
 		if err = s.UserRepo.Set(user); err != nil {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("failed to update user: %+v", err))
 			return

--- a/financroo/connect_bank_routes.go
+++ b/financroo/connect_bank_routes.go
@@ -166,6 +166,7 @@ func (s *Server) ConnectedBanks() func(*gin.Context) {
 			if tokenResponse, err = clients.RenewAccountsToken(b); err != nil {
 				logrus.Warnf("failed to renew token for bank: %s", b.BankID)
 				expiredBanks = append(expiredBanks, b.BankID)
+				continue
 			}
 			logrus.Infof("XXX tokenResponse: %+v", tokenResponse)
 

--- a/financroo/connect_bank_routes.go
+++ b/financroo/connect_bank_routes.go
@@ -123,7 +123,6 @@ func (s *Server) ConnectBankCallback() func(*gin.Context) {
 			return
 		}
 
-		logrus.Infof("connect bank callback: %+v", token)
 		if err = s.ConnectBankForUser(appStorage, token); err != nil {
 			c.String(http.StatusUnauthorized, fmt.Sprintf("failed to exchange code: %+v", err))
 			return
@@ -138,15 +137,14 @@ func (s *Server) ConnectBankCallback() func(*gin.Context) {
 func (s *Server) ConnectedBanks() func(*gin.Context) {
 	return func(c *gin.Context) {
 		var (
-			user              User
-			err               error
-			clients           Clients
-			tokenResponse     *models.TokenResponse
-			ok                bool
-			connectedBanks    = []string{}
-			expiredBanks      = []string{}
-			tokens            = []BankToken{}
-			userSecureStorage = NewUserSecureStorage(s.SecureCookie)
+			user           User
+			err            error
+			clients        Clients
+			tokenResponse  *models.TokenResponse
+			ok             bool
+			connectedBanks = []string{}
+			expiredBanks   = []string{}
+			tokens         = []BankToken{}
 		)
 
 		if user, _, err = s.WithUser(c); err != nil {
@@ -182,7 +180,7 @@ func (s *Server) ConnectedBanks() func(*gin.Context) {
 			return
 		}
 
-		if err = userSecureStorage.Store(c, tokens); err != nil {
+		if err = s.UserSecureStorage.Store(c, tokens); err != nil {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("error while storing user data: %+v", err))
 			return
 		}

--- a/financroo/connect_bank_routes.go
+++ b/financroo/connect_bank_routes.go
@@ -153,11 +153,8 @@ func (s *Server) ConnectedBanks() func(*gin.Context) {
 			c.String(http.StatusUnauthorized, err.Error())
 			return
 		}
-		logrus.Infof("XXX authenticated user: %+v", user)
 
 		for i, b := range user.Banks {
-			logrus.Infof("XXX refresh token flow for bank: %s", b.BankID)
-
 			if clients, ok = s.Clients[BankID(b.BankID)]; !ok {
 				c.String(http.StatusInternalServerError, fmt.Sprintf("client not configured for bank: %s", b.BankID))
 				return
@@ -168,7 +165,6 @@ func (s *Server) ConnectedBanks() func(*gin.Context) {
 				expiredBanks = append(expiredBanks, b.BankID)
 				continue
 			}
-			logrus.Infof("XXX tokenResponse: %+v", tokenResponse)
 
 			connectedBanks = append(connectedBanks, b.BankID)
 
@@ -245,7 +241,6 @@ func (s *Server) ConnectBankForUser(appStorage AppStorage, token acpclient.Token
 	if user, err = s.UserRepo.Get(appStorage.Sub); err != nil {
 		return errors.Wrapf(err, "failed to get user")
 	}
-	logrus.Infof("XXX user: %+v", user)
 
 	for i, b := range user.Banks {
 		if b.BankID == string(appStorage.BankID) {

--- a/financroo/domestic_payment_routes.go
+++ b/financroo/domestic_payment_routes.go
@@ -34,7 +34,7 @@ func (s *Server) CreateDomesticPaymentConsent() func(*gin.Context) {
 			err                   error
 		)
 
-		if user, err = s.WithUser(c); err != nil {
+		if user, _, err = s.WithUser(c); err != nil {
 			c.String(http.StatusUnauthorized, err.Error())
 			return
 		}
@@ -51,13 +51,13 @@ func (s *Server) CreateDomesticPaymentConsent() func(*gin.Context) {
 		schema := "UK.OBIE.SortCodeAccountNumber"
 		authorisationType := "Single"
 		account := models.DomesticPaymentConsentCreditorAccount{
-			Identification:          &paymentConsentRequest.PayeeAccountNumber,
-			Name:                    &paymentConsentRequest.PayeeAccountName,
-			SchemeName:              &schema,
+			Identification: &paymentConsentRequest.PayeeAccountNumber,
+			Name:           &paymentConsentRequest.PayeeAccountName,
+			SchemeName:     &schema,
 		}
 		debtorAccount := models.DomesticPaymentConsentDebtorAccount{
 			Identification: &paymentConsentRequest.AccountID,
-			Name: "myAccount", // todo
+			Name:           "myAccount", // todo
 			SchemeName:     &schema,
 		}
 		id := uuid.New().String()[:10]
@@ -68,15 +68,15 @@ func (s *Server) CreateDomesticPaymentConsent() func(*gin.Context) {
 				WithAid(clients.AcpPaymentsClient.ServerID).
 				WithRequest(&models.DomesticPaymentConsentRequest{
 					Data: &models.DomesticPaymentConsentRequestData{
-						Authorisation:     &models.DomesticPaymentConsentAuthorisation{
+						Authorisation: &models.DomesticPaymentConsentAuthorisation{
 							AuthorisationType:  &authorisationType,
 							CompletionDateTime: strfmt.DateTime(time.Now().Add(time.Hour)),
 						},
-						Initiation:        &models.DomesticPaymentConsentDataInitiation{
-							CreditorAccount:           &account,
-							DebtorAccount:             &debtorAccount,
-							EndToEndIdentification:    &id,
-							InstructedAmount:          &models.DomesticPaymentConsentInstructedAmount{
+						Initiation: &models.DomesticPaymentConsentDataInitiation{
+							CreditorAccount:        &account,
+							DebtorAccount:          &debtorAccount,
+							EndToEndIdentification: &id,
+							InstructedAmount: &models.DomesticPaymentConsentInstructedAmount{
 								Amount:   &paymentConsentRequest.Amount,
 								Currency: &currency,
 							},
@@ -129,4 +129,3 @@ func (s *Server) DomesticPaymentCallback() func(*gin.Context) {
 		c.Redirect(http.StatusFound, s.Config.UIURL)
 	}
 }
-

--- a/financroo/server.go
+++ b/financroo/server.go
@@ -15,13 +15,14 @@ import (
 )
 
 type Server struct {
-	Config       Config
-	Clients      map[BankID]Clients
-	SecureCookie *securecookie.SecureCookie
-	DB           *bolt.DB
-	UserRepo     UserRepo
-	LoginClient  acpclient.Client
-	Validator    *validator.Validate
+	Config            Config
+	Clients           map[BankID]Clients
+	SecureCookie      *securecookie.SecureCookie
+	DB                *bolt.DB
+	UserRepo          UserRepo
+	LoginClient       acpclient.Client
+	Validator         *validator.Validate
+	UserSecureStorage UserSecureStorage
 }
 
 func NewServer() (Server, error) {
@@ -56,6 +57,8 @@ func NewServer() (Server, error) {
 	if server.UserRepo, err = NewUserRepo(server.DB); err != nil {
 		return server, errors.Wrapf(err, "failed to init user repo")
 	}
+
+	server.UserSecureStorage = NewUserSecureStorage(server.SecureCookie)
 
 	return server, nil
 }

--- a/financroo/server.go
+++ b/financroo/server.go
@@ -14,44 +14,6 @@ import (
 	acpclient "github.com/cloudentity/acp-client-go"
 )
 
-type Clients struct {
-	AcpAccountsClient  acpclient.Client
-	AcpPaymentsClient  acpclient.Client
-	BankClient         OpenbankingClient
-}
-
-func InitClients(config Config) (map[BankID]Clients, error) {
-	var (
-		clients              = map[BankID]Clients{}
-		acpAccountsWebClient acpclient.Client
-		acpPaymentsWebClient acpclient.Client
-		bankClient           OpenbankingClient
-		err                  error
-	)
-
-	for _, bank := range config.Banks {
-		if acpAccountsWebClient, err = NewAcpClient(config, bank, "/api/callback"); err != nil {
-			return clients, errors.Wrapf(err, "failed to init acp web client for bank: %s", bank.ID)
-		}
-
-		if acpPaymentsWebClient, err = NewAcpClient(config, bank, "/api/domestic/callback"); err != nil {
-			return clients, errors.Wrapf(err, "failed to init acp web client for bank: %s", bank.ID)
-		}
-
-		if bankClient, err = NewOpenbankingClient(bank); err != nil {
-			return clients, errors.Wrapf(err, "failed to init client for bank: %s", bank.ID)
-		}
-
-		clients[bank.ID] = Clients{
-			AcpAccountsClient:  acpAccountsWebClient,
-			AcpPaymentsClient:  acpPaymentsWebClient,
-			BankClient: bankClient,
-		}
-	}
-
-	return clients, nil
-}
-
 type Server struct {
 	Config       Config
 	Clients      map[BankID]Clients
@@ -85,8 +47,7 @@ func NewServer() (Server, error) {
 	if server.LoginClient, err = NewLoginClient(server.Config); err != nil {
 		return server, errors.Wrapf(err, "failed to init login client")
 	}
-
-	server.SecureCookie = securecookie.New(securecookie.GenerateRandomKey(64), securecookie.GenerateRandomKey(32))
+	server.SecureCookie = securecookie.New(server.Config.CookieHashKey, server.Config.CookieBlockKey)
 
 	if server.DB, err = InitDB(server.Config); err != nil {
 		return server, errors.Wrapf(err, "failed to init db")

--- a/financroo/user_secure_storage.go
+++ b/financroo/user_secure_storage.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/securecookie"
+)
+
+type BankTokens []BankToken
+
+func (b *BankTokens) GetAccessToken(bankID string) (string, error) {
+	for _, x := range *b {
+		if x.BankID == bankID {
+			// check if expired
+			return x.AccessToken, nil
+		}
+	}
+
+	return "", fmt.Errorf("no access token found for bank: %s", bankID)
+
+}
+
+type BankToken struct {
+	BankID      string `json:"bank_id"`
+	AccessToken string `json:"access_token"`
+	ExpiresAt   int64  `json:"expires_at"`
+}
+
+type UserSecureStorage struct {
+	sc *securecookie.SecureCookie
+}
+
+func NewUserSecureStorage(sc *securecookie.SecureCookie) UserSecureStorage {
+	return UserSecureStorage{sc: sc}
+}
+
+func (s *UserSecureStorage) Store(c *gin.Context, tokens BankTokens) error {
+	var (
+		encodedData string
+		err         error
+	)
+	if encodedData, err = s.sc.Encode("data", tokens); err != nil {
+		return err
+	}
+
+	c.SetCookie("data", encodedData, 0, "/", "", false, true)
+
+	return nil
+}
+
+func (s *UserSecureStorage) Read(c *gin.Context) (BankTokens, error) {
+	var (
+		encodedData string
+		tokens      []BankToken
+		err         error
+	)
+
+	if encodedData, err = c.Cookie("data"); err != nil {
+		return BankTokens{}, nil
+	}
+
+	if err = s.sc.Decode("data", encodedData, &tokens); err != nil {
+		return tokens, err
+	}
+
+	return tokens, nil
+}


### PR DESCRIPTION
- access tokens to connected banks are stored now in a secure cookie
- UI after login hits /api/banks endpoint which issues new access tokens based on refresh token stored in db