### PR TITLE
fixes accidental mutation of accounts when setting domestic payment status

### DIFF
--- a/bank/repo.go
+++ b/bank/repo.go
@@ -225,16 +225,15 @@ func (ur *UserRepo) writeData(bucket, key []byte, data Data) error {
 }
 
 func (ur *UserRepo) loadAll(m map[string]Data) error {
-	var (
-		data Data
-		err  error
-	)
-
 	return ur.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketName)
 		c := b.Cursor()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			var (
+				data Data
+				err  error
+			)
 			if err = json.Unmarshal(v, &data); err != nil {
 				return errors.Wrapf(err, fmt.Sprintf("failed to unmarshal data for user %s", string(k)))
 			}


### PR DESCRIPTION
As an example, the bills account id kept mutating to 11920, but now is now stable
<img width="889" alt="Screen Shot 2021-04-08 at 2 32 01 PM" src="https://user-images.githubusercontent.com/77007607/114078729-49b41180-9877-11eb-8b92-e9249964fc5f.png">
